### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,12 @@ name: Documentation
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/docs.yml
   workflow_dispatch:
 
 permissions:
@@ -17,8 +22,9 @@ concurrency:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build Documentation
@@ -40,6 +46,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
     steps:
     - name: Deploy to GitHub Pages
       id: deployment

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,13 +2,32 @@ name: macOS
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macOS:
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,14 +2,33 @@ name: ubuntu
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+
+concurrency:
+  group: ubuntu-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
     container: swift:6.0
+    timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
Standardizes GitHub Actions for this PUBLIC swift-spm library, mirroring the CorvidLabs/merlin CI standard.

- macOS.yml (CI): scoped push/PR to `main` with a swift-spm `paths:` filter (Sources/**, Tests/**, Package.swift, Package.resolved, the workflow file); added `pull_request` trigger; added `concurrency` group with cancel-in-progress; bumped to actions/checkout@v5; added timeout-minutes. Runner macos-latest unchanged (correct for public).
- ubuntu.yml (CI): same paths filter, pull_request trigger, concurrency, checkout@v5, timeout-minutes. Runner ubuntu-latest (swift:6.0 container) unchanged.
- docs.yml (pages/deploy): added a site-source-scoped `paths:` set (Sources/**, Package.swift, the workflow); checkout@v5; timeout-minutes on both jobs. Kept cancel-in-progress: false (intentional for in-flight Pages deploys). Runners (macos-latest build + ubuntu-latest deploy) unchanged — correct for public.

Notes: README/docs/LICENSE-only changes now match no path set and trigger no CI. No fledge.toml present, so native swift build/test commands are preserved.

Mirrors the CorvidLabs/merlin CI standard.