### PR TITLE
Fix: point SPM install and docs links at CorvidLabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Add the following to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/0xLeif/swift-music.git", from: "0.1.0")
+    .package(url: "https://github.com/CorvidLabs/swift-music.git", from: "0.1.0")
 ]
 ```
 
 Or in Xcode:
 1. File → Add Package Dependencies...
-2. Enter package URL: `https://github.com/0xLeif/swift-music.git`
+2. Enter package URL: `https://github.com/CorvidLabs/swift-music.git`
 3. Select version and add to your target
 
 ## Usage
@@ -308,7 +308,7 @@ Contributions are welcome! Please ensure all code:
 
 ## Documentation
 
-Full API documentation is available at [https://0xleif.github.io/swift-music/documentation/music/](https://0xleif.github.io/swift-music/documentation/music/)
+Full API documentation is available at [https://corvidlabs.github.io/swift-music/documentation/music/](https://corvidlabs.github.io/swift-music/documentation/music/)
 
 ## License
 


### PR DESCRIPTION
Problem: Installation block and docs link point to the personal account 0xLeif (package URL https://github.com/0xLeif/swift-music.git, Xcode URL, and docs https://0xleif.github.io/swift-music/documentation/music/), while the CI/License/Version badges and the canonical org repo are CorvidLabs/swift-music. The install instructions reference a different org than the actual repo home.

Fix: Update the SwiftPM and Xcode package URLs to https://github.com/CorvidLabs/swift-music.git and the documentation link to the CorvidLabs GitHub Pages URL (or confirm and keep the 0xLeif redirect intentionally, but make all references consistent with the badges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)